### PR TITLE
adjust ss bounds for complete and min power

### DIFF
--- a/R/pump_mdes.R
+++ b/R/pump_mdes.R
@@ -164,8 +164,10 @@ pump_mdes <- function(
   mdes.low <- mdes.raw
   mdes.high <- mdes.bf
   
-  # complete power
-  if(pdef$complete)
+  # adjust bounds to capture needed range
+  # for minimum or complete power, expand bounds
+  # note: complete power is a special case of minimum power
+  if(pdef$min)
   {
       # complete power will have a higher upper bound
       # must detect all individual outcomes
@@ -176,11 +178,7 @@ pump_mdes <- function(
       mdes.high   <- ifelse(target.indiv.power > 0.5,
                           Q.m * (crit.alphaxM + crit.beta),
                           Q.m * (crit.alphaxM - crit.beta))
-  }
-  
-  # min power
-  if(pdef$min)
-  {
+      
       # min1 power will have a lower lower bound
       # must detect at least one individual outcome
       min.target.indiv.power <- 1 - (1 - target.power)^(1/M)

--- a/R/pump_sample.R
+++ b/R/pump_sample.R
@@ -644,7 +644,11 @@ pump_sample <- function(
   pdef <- parse_power_definition( power.definition, M )
 
   # adjust bounds to capture needed range
+  # for minimum or complete power, expand bounds
+  # note: complete power is a special case of minimum power
   if ( pdef$min ) {
+     
+    # lower bound needs to be lower
     need_pow <- 1 - (1 - target.power)^(1/M)
     ss.low <- pump_sample_raw(
       design = design, MTP = MTP, typesample = typesample,
@@ -656,10 +660,8 @@ pump_sample <- function(
       numCovar.1 = numCovar.1, numCovar.2 = numCovar.2, numCovar.3 = numCovar.3,
       R2.1 = R2.1, R2.2 = R2.2, R2.3 = R2.3, ICC.2 = ICC.2, ICC.3 = ICC.3,
       omega.2 = omega.2, omega.3 = omega.3 )
-  }
-  
-  if( pdef$complete )
-  {
+    
+    # higher bound needs to be higher
     need_pow <- (target.power^(1/M))
     ss.high <- pump_sample_raw(
         design = design, MTP = MTP, typesample = typesample,


### PR DESCRIPTION
@lmiratrix can you take a look at the changes I highlight below?  I made the following adjustments:

1. If min power, we need to adjust the lower bound down, but not the upper bound.
2. If complete power, we need to adjust the upper bound up, but not the lower bound.
3. I fixed a possible typo in adjusting alpha assuming BF when you are calculating a raw p-value

(A lot of the changes are formatting so I commented on the relevant lines, no need to review the rest)