### PR TITLE
Increase tolerance to accommodate small inaccuracies in exp().

### DIFF
--- a/tests/testthat/test-pump_sample.R
+++ b/tests/testthat/test-pump_sample.R
@@ -230,7 +230,7 @@ test_that("pump_sample 2 level/2 level", {
                     rho = 0.4 )
 
   p2
-  expect_equal( p2[ 2, "indiv.mean" ], 0.80, tol = 0.02 )
+  expect_equal( p2[ 2, "indiv.mean" ], 0.80, tol = 0.03 )
 } )
 
 


### PR DESCRIPTION
On Windows Server 2022 with mingw-w64 v12, where exp() is used from UCRT, the package fails its checks:

```
  ── Failure ('test-pump_sample.R:233:3'): pump_sample 2 level/2 level ───────────
  p2[2, "indiv.mean"] not equal to 0.8.
  1/1 mismatches
  [1] 0.821 - 0.8 == 0.021
```
The differences in exp() results computed by the checks from mingw-w64 v11, where exp() is used from an internal implementation, are all within 1 ULP, so it seems the check is overly sensitive.

This patch increases the tolerance and makes the package pass. Mingw-w64 v12 will very likely be used in the next version of Rtools.
